### PR TITLE
백엔드 API 호출 함수 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-frontend/node_modules
-frontend/.vite
+node_modules
+.vite
 dist
 dist-ssr
 *.local

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 3101",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/src/constants/service.ts
+++ b/src/constants/service.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;

--- a/src/constants/service.ts
+++ b/src/constants/service.ts
@@ -1,1 +1,2 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+export const WEBSOCKET_BASE_URL = import.meta.env.VITE_WEBSOCKET_BASE_URL;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -15,9 +15,6 @@ import { useUserStateStore } from '@/states/user';
 import { ROUTE } from '@/router/constants';
 
 export const getGuestLogin = async () => {
-  if (!(localStorage.getItem('presentation') === 'on')) {
-    return false;
-  }
   return api
     .get<string>(false, '/user/guest')
     .then((response) => {

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -1,3 +1,3 @@
 const BASE_URL = 'nocolored.world';
-export const API_URL = `https://${BASE_URL}/api`;
+
 export const WEBSOCKET_URL = `wss://${BASE_URL}/api/game`;

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -1,3 +1,0 @@
-const BASE_URL = 'nocolored.world';
-
-export const WEBSOCKET_URL = `wss://${BASE_URL}/api/game`;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,28 +1,26 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 
-import { API_URL } from '@/services/constants';
+import { API_BASE_URL } from '@/constants/service';
 
-const $axios = (requiredToken: boolean) => {
-  const client = axios.create({
-    baseURL: API_URL,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    // withCredentials: true,
-  });
+const client = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  // withCredentials: true,
+});
 
-  if (requiredToken) {
-    client.interceptors.request.use((config) => {
-      const token = localStorage.getItem('token');
-      if (token) {
-        config.headers.Authorization = token;
-      }
-      return config;
-    });
+client.interceptors.request.use((config) => {
+  if (config.headers['X-Bypass-Authorization']) {
+    return config;
   }
 
-  return client;
-};
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = token;
+  }
+  return config;
+});
 
 const api = {
   post: async <T, P>(
@@ -30,14 +28,22 @@ const api = {
     url: string,
     data: P,
   ): Promise<AxiosResponse<T>> => {
-    return $axios(requiredToken).post<T>(url, data);
+    return client.post<T>(url, data, {
+      headers: {
+        'X-Bypass-Authorization': !requiredToken,
+      },
+    });
   },
 
   get: async <T>(
     requiredToken: boolean,
     url: string,
   ): Promise<AxiosResponse<T>> => {
-    return $axios(requiredToken).get<T>(url);
+    return client.get<T>(url, {
+      headers: {
+        'X-Bypass-Authorization': !requiredToken,
+      },
+    });
   },
 
   patch: async <T, P>(
@@ -45,14 +51,22 @@ const api = {
     url: string,
     data: P,
   ): Promise<AxiosResponse<T>> => {
-    return $axios(requiredToken).patch<T>(url, data);
+    return client.patch<T>(url, data, {
+      headers: {
+        'X-Bypass-Authorization': !requiredToken,
+      },
+    });
   },
 
   delete: async <T>(
     requiredToken: boolean,
     url: string,
   ): Promise<AxiosResponse<T>> => {
-    return $axios(requiredToken).delete<T>(url);
+    return client.delete<T>(url, {
+      headers: {
+        'X-Bypass-Authorization': !requiredToken,
+      },
+    });
   },
 };
 

--- a/src/services/websocket/Socket.ts
+++ b/src/services/websocket/Socket.ts
@@ -4,7 +4,7 @@ import type {
   WebSocketMessageHandler,
 } from '@/types/websocket';
 
-import { WEBSOCKET_URL } from '@/services/constants';
+import { WEBSOCKET_BASE_URL } from '@/constants/service';
 
 export class Socket {
   protected webSocket: WebSocket;
@@ -14,7 +14,7 @@ export class Socket {
   }
 
   connect() {
-    this.webSocket = new WebSocket(WEBSOCKET_URL);
+    this.webSocket = new WebSocket(WEBSOCKET_BASE_URL);
 
     this.webSocket.onopen = () => {
       this.sendToken();


### PR DESCRIPTION
## 관련 이슈
- #1 

## 작업 내용
- 백엔드 연결 주소를 환경변수로 분리
  - 관리 편의를 위해 `@/services/constant`에서 `@/constants` 폴더로 이동
- api 호출 함수 리팩토링
  - axios 객체를 한 번만 생성하도록 수정
- 과거 발표를 위해 추가했던 코드 삭제
- 백엔드와 레포지토리 분리된 영향으로 `.gitignore` 수정
- 개발 환경에서 백엔드 통신을 위해 포트번호를 3101로 고정